### PR TITLE
[BE] feature: Oauth 로그인 API 구현(카카오, 구글)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,14 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/dev/easylogbe/common/exception/ErrorCode.java
+++ b/src/main/java/dev/easylogbe/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package dev.easylogbe.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    INTERNAL_SEVER_ERROR(5000, "서버 내부 예외입니다."),
+    JWT_INVALID_SIGNATURE(4000, "잘못된 JWT 서명입니다."),
+    JWT_EXPIRED(4001, "만료된 JWT 입니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/dev/easylogbe/common/util/JwtProvider.java
+++ b/src/main/java/dev/easylogbe/common/util/JwtProvider.java
@@ -1,0 +1,78 @@
+package dev.easylogbe.common.util;
+
+import dev.easylogbe.common.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @Value("${spring.jwt.issuer}")
+    private String issuer;
+
+    @Value("${spring.jwt.access-token-expiration-minutes}")
+    private int accessTokenExpirationMinutes;
+
+    @Value("${spring.jwt.refresh-token-expiration-minutes}")
+    private int refreshTokenExpirationMinutes;
+
+    public String createJwt(Long userId, boolean isAccessToken) {
+        Instant now = Instant.now();
+        Map<String, Object> claims = createClaims(userId);
+        int tokenExpirationMinutes = getTokenExpirationMinutes(isAccessToken);
+        return Jwts.builder()
+                .issuer(issuer)
+                .subject(String.valueOf(userId))
+                .claims(claims)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(tokenExpirationMinutes, ChronoUnit.MINUTES)))
+                .signWith(getSecretKey())
+                .compact();
+    }
+
+    private int getTokenExpirationMinutes(boolean isAccessToken) {
+        return isAccessToken ? accessTokenExpirationMinutes : refreshTokenExpirationMinutes;
+    }
+
+    public Claims getClaims(String accessToken) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSecretKey())
+                    .build()
+                    .parseSignedClaims(accessToken)
+                    .getPayload();
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new JwtException(ErrorCode.JWT_INVALID_SIGNATURE.getMessage());
+        } catch (ExpiredJwtException | UnsupportedJwtException e) {
+            throw new JwtException(ErrorCode.JWT_EXPIRED.getMessage());
+        }
+    }
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(this.secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Map<String, Object> createClaims(Long userId) {
+        return Map.of(
+                "id", userId
+        );
+    }
+}

--- a/src/main/java/dev/easylogbe/oauth/controller/OauthController.java
+++ b/src/main/java/dev/easylogbe/oauth/controller/OauthController.java
@@ -1,0 +1,29 @@
+package dev.easylogbe.oauth.controller;
+
+import dev.easylogbe.oauth.dto.response.OauthLoginResponse;
+import dev.easylogbe.oauth.service.OauthService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/oauth")
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @GetMapping("/{provider}")
+    public ResponseEntity<OauthLoginResponse> oauthLogin(@PathVariable String provider,
+                                                         @RequestParam String code,
+                                                         HttpServletResponse httpServletResponse) {
+
+        OauthLoginResponse res = oauthService.login(provider, code, httpServletResponse);
+        return ResponseEntity.ok().body(res);
+    }
+}

--- a/src/main/java/dev/easylogbe/oauth/domain/OauthUserInfo.java
+++ b/src/main/java/dev/easylogbe/oauth/domain/OauthUserInfo.java
@@ -1,0 +1,13 @@
+package dev.easylogbe.oauth.domain;
+
+public interface OauthUserInfo {
+    String getProviderId();
+
+    String getProvider();
+
+    String getEmail();
+
+    String getNickname();
+
+    String getProfileImgUrl();
+}

--- a/src/main/java/dev/easylogbe/oauth/domain/OauthUserInfoImpl.java
+++ b/src/main/java/dev/easylogbe/oauth/domain/OauthUserInfoImpl.java
@@ -1,0 +1,68 @@
+package dev.easylogbe.oauth.domain;
+
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.EMAIL;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.GOOGLE_NICKNAME;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.GOOGLE_PROFILE_IMG_URL;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.ID;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.KAKAO_ACCOUNT;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.KAKAO_NICKNAME;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.KAKAO_PROFILE_IMG_URL;
+import static dev.easylogbe.oauth.util.OauthUserInfoRequestConst.PROFILE;
+
+import dev.easylogbe.oauth.enumtype.OauthProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OauthUserInfoImpl implements OauthUserInfo{
+
+    private final Map<String, Object> attributes;
+    private final String provider;
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get(ID));
+    }
+
+    @Override
+    public String getProvider() {
+        String kakao = OauthProvider.KAKAO.getValue();
+        if (this.provider.equals(kakao)) {
+            return kakao;
+        }
+        return OauthProvider.GOOGLE.getValue();
+    }
+
+    @Override
+    public String getEmail() {
+        String kakao = OauthProvider.KAKAO.getValue();
+        if (this.provider.equals(kakao)) {
+            return (String) getKakaoAccount().get(EMAIL);
+        }
+        return (String) attributes.get(EMAIL);
+    }
+
+    @Override
+    public String getNickname() {
+        if (this.provider.equals(OauthProvider.KAKAO.getValue())) {
+            return (String) getProfile().get(KAKAO_NICKNAME);
+        }
+        return (String) attributes.get(GOOGLE_NICKNAME);
+    }
+
+    @Override
+    public String getProfileImgUrl() {
+        if (this.provider.equals(OauthProvider.KAKAO.getValue())) {
+            return (String) getProfile().get(KAKAO_PROFILE_IMG_URL);
+        }
+        return (String) attributes.get(GOOGLE_PROFILE_IMG_URL);
+    }
+
+    public Map<String, Object> getKakaoAccount() {
+        return (Map<String, Object>) attributes.get(KAKAO_ACCOUNT);
+    }
+
+    public Map<String, Object> getProfile() {
+        return (Map<String, Object>) getKakaoAccount().get(PROFILE);
+    }
+}

--- a/src/main/java/dev/easylogbe/oauth/dto/OauthTokenDTO.java
+++ b/src/main/java/dev/easylogbe/oauth/dto/OauthTokenDTO.java
@@ -1,0 +1,21 @@
+package dev.easylogbe.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OauthTokenDTO(
+        @JsonProperty(value = "token_type")
+        String tokeType,
+
+        @JsonProperty(value = "access_token")
+        String accessToken,
+
+        @JsonProperty(value = "expires_in")
+        Integer expiresIn,
+
+        @JsonProperty(value = "refresh_token")
+        String refreshToken,
+
+        @JsonProperty(value = "refresh_token_expires_in")
+        Integer refreshTokenExpiresIn
+) {
+}

--- a/src/main/java/dev/easylogbe/oauth/dto/response/OauthLoginResponse.java
+++ b/src/main/java/dev/easylogbe/oauth/dto/response/OauthLoginResponse.java
@@ -1,0 +1,25 @@
+package dev.easylogbe.oauth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.easylogbe.oauth.domain.OauthUserInfoImpl;
+
+public record OauthLoginResponse(
+        String email,
+        String nickname,
+        @JsonProperty(value = "profile_img_url")
+        String profileImgUrl,
+        @JsonProperty(value = "refresh_token")
+        String refreshToken,
+        @JsonProperty(value = "is_registered")
+        boolean isRegistered
+) {
+    public static OauthLoginResponse of(OauthUserInfoImpl oauthUserInfo, String refreshToken, boolean isRegistered) {
+        return new OauthLoginResponse(
+                oauthUserInfo.getEmail(),
+                oauthUserInfo.getNickname(),
+                oauthUserInfo.getProfileImgUrl(),
+                refreshToken,
+                isRegistered
+        );
+    }
+}

--- a/src/main/java/dev/easylogbe/oauth/service/OauthService.java
+++ b/src/main/java/dev/easylogbe/oauth/service/OauthService.java
@@ -1,0 +1,123 @@
+package dev.easylogbe.oauth.service;
+
+import dev.easylogbe.common.util.JwtProvider;
+import dev.easylogbe.oauth.domain.OauthUserInfoImpl;
+import dev.easylogbe.oauth.dto.OauthTokenDTO;
+import dev.easylogbe.oauth.dto.response.OauthLoginResponse;
+import dev.easylogbe.user.domain.User;
+import dev.easylogbe.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final InMemoryClientRegistrationRepository clientRegistrationRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    public OauthLoginResponse login(String provider, String code, HttpServletResponse httpServletResponse) {
+        //TODO request dto validation 적용시 수정 필요
+        if(provider == null || provider.isEmpty()) {
+            throw new IllegalArgumentException("provider can't null or empty");
+        }
+        if(code == null || code.isEmpty()) {
+            throw new IllegalArgumentException("code can't null or empty");
+        }
+
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(provider);
+        OauthTokenDTO oauthToken = getOauthToken(code, clientRegistration);
+        OauthUserInfoImpl oauthUserInfo = getUserInfoFromOauth(provider, oauthToken, clientRegistration);
+
+        String email = oauthUserInfo.getEmail();
+        Optional<User> optionalUser =
+                userRepository.findByEmail(email);
+
+        /*
+         * 서비스에 등록된 유저인 경우 Access, Refresh 토큰을 발급해줌
+         * Oauth 에 등록된 유저정보와 서비스에 가입된 유저인지 여부를 응답(API 스펙)
+         */
+        if(optionalUser.isPresent()) {
+            User registerdUser = optionalUser.get();
+            Long userId = registerdUser.getId();
+
+            String accessToken = jwtProvider.createJwt(userId, true);
+            httpServletResponse.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+
+            String refreshToken = jwtProvider.createJwt(userId, false);
+            return OauthLoginResponse.of(oauthUserInfo, refreshToken, true);
+        }
+        // 등록되지 않은 유저라면 토큰을 발급하지 않고, Oauth2 유저정보와 가입되지 않았다는 flag 만 리턴
+        return OauthLoginResponse.of(oauthUserInfo, null, false);
+    }
+
+    /**
+     * @param code oauth2 url 로 부터 발급받은 code
+     * @param clientRegistration YML 에 등록된 provider(kakao, google) Oauth2 메타데이터 레지스트리
+     * @return 발급된 code 로 oauth2 api 에 요청을 보내 oauthToken 을 리턴
+     */
+    private OauthTokenDTO getOauthToken(String code, ClientRegistration clientRegistration) {
+        return WebClient.create()
+                .post()
+                .uri(clientRegistration.getProviderDetails().getTokenUri())
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(createOauthRequestBody(code, clientRegistration))
+                .retrieve()
+                .bodyToMono(OauthTokenDTO.class)
+                .block();
+    }
+
+    /**
+     * @param code oauth2 url 로 부터 발급받은 code
+     * @param clientRegistration YML 에 등록된 provider(kakao, google) Oauth2 메타데이터 레지스트리
+     * @return oauth2 api 요청 바디를 리턴
+     */
+    private MultiValueMap<String, String> createOauthRequestBody(String code, ClientRegistration clientRegistration) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", clientRegistration.getRedirectUri());
+        formData.add("client_secret", clientRegistration.getClientSecret());
+        formData.add("client_id", clientRegistration.getClientId());
+        return formData;
+    }
+
+    private OauthUserInfoImpl getUserInfoFromOauth(String provider, OauthTokenDTO oauthToken,
+                                                   ClientRegistration clientRegistration) {
+        Map<String, Object> userAttributes = getUserAttribute(clientRegistration, oauthToken);
+        return new OauthUserInfoImpl(userAttributes, provider);
+    }
+
+    /**
+     * @param clientRegistration YML 에 등록된 provider(kakao, google) Oauth2 메타데이터 레지스트리
+     * @param oauthToken 외부 API 에서 발급받은 oauthToken
+     * @return 발급받은 oauthToken 으로 등록된 oauth 유저 정보를 리턴
+     */
+    private Map<String, Object> getUserAttribute(ClientRegistration clientRegistration, OauthTokenDTO oauthToken) {
+        return WebClient.create()
+                .get()
+                .uri(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(oauthToken.accessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+    }
+}

--- a/src/main/java/dev/easylogbe/oauth/util/OauthUserInfoRequestConst.java
+++ b/src/main/java/dev/easylogbe/oauth/util/OauthUserInfoRequestConst.java
@@ -1,0 +1,12 @@
+package dev.easylogbe.oauth.util;
+
+public final class OauthUserInfoRequestConst {
+    public static final String ID = "id";
+    public static final String EMAIL = "email";
+    public static final String PROFILE = "profile";
+    public static final String KAKAO_ACCOUNT = "kakao_account";
+    public static final String KAKAO_NICKNAME = "nickname";
+    public static final String KAKAO_PROFILE_IMG_URL = "profile_image_url";
+    public static final String GOOGLE_PROFILE_IMG_URL = "picture";
+    public static final String GOOGLE_NICKNAME = "name";
+}

--- a/src/main/java/dev/easylogbe/user/repository/UserRepository.java
+++ b/src/main/java/dev/easylogbe/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package dev.easylogbe.user.repository;
 
 import dev.easylogbe.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
- [x] ✅ PR 제목의 형식을 잘 작성했나요? e.g. `[BE] feature: PR을 등록한다.`
- [x] ✅ 테스트는 잘 통과했나요?
- [x] ✅ 빌드는 성공했나요?
- [x] ✅ 불필요한 코드는 제거했나요?
- [x] ✅ 이슈는 등록했나요?
- [x] ✅ 라벨은 등록했나요?
- [x] ✅ 코드 컨벤션은 지켰나요?

## 작업 내용
- 카카오, 구글 oauth2 로그인 API
- JwtProvider(토큰발급) 컴포넌트 구현
- 기본 에러코드 클래스 구현
- Webflux, OauthClient, Jwt 의존성 추가
## 스크린샷

## 주의사항
- Jwt 및 Oauth 관련 메타데이터 YML 파일 팀 노션 확인 후 사용필요!
Closes #3 